### PR TITLE
feat(proxy): implement NIP-48 tag

### DIFF
--- a/nostrss-core/src/scheduler/scheduler.rs
+++ b/nostrss-core/src/scheduler/scheduler.rs
@@ -156,7 +156,7 @@ impl RssNostrJob {
                     let mut tags = Self::get_tags(&feed.tags);
 
                     // Declare NIP-48.
-                    tags.push(Self::get_nip48(&tags, feed.id.clone()));
+                    tags.push(Self::get_nip48(&tags, entry.id.clone()));
 
                     let message = match TemplateProcessor::parse(feed.clone(), entry.clone()) {
                         Ok(message) => message,
@@ -230,11 +230,11 @@ impl RssNostrJob {
         tags
     }
 
-    fn get_nip48(mut tags: &Vec<Tag>, feed_id: String) -> Tag {
+    fn get_nip48(mut tags: &Vec<Tag>, guid: String) -> Tag {
         // Declare NIP-48.
         // NIP-48 : declares to be a proxy from an external signal (rss,activityPub)
         Tag::Proxy {
-            id: feed_id,
+            id: guid,
             protocol: nostr_sdk::prelude::Protocol::Rss,
         }
     }
@@ -295,9 +295,9 @@ mod tests {
 
     #[test]
     fn test_nip_48() {
-        let feed_id = "https://www.test.com";
+        let guid = "https://www.test.com";
         let mut tags: Vec<Tag> = [].to_vec();
-        let nip_48 = RssNostrJob::get_nip48(&tags, feed_id.clone().to_string());
+        let nip_48 = RssNostrJob::get_nip48(&tags, guid.clone().to_string());
 
         assert_eq!(nip_48.kind(), TagKind::Proxy);
     }

--- a/nostrss-core/src/scheduler/scheduler.rs
+++ b/nostrss-core/src/scheduler/scheduler.rs
@@ -230,16 +230,16 @@ impl RssNostrJob {
         tags
     }
 
-    fn get_nip48(mut tags: &Vec<Tag>,feed_id:  String) -> Tag {
-            // Declare NIP-48.
-            // NIP-48 : declares to be a proxy from an external signal (rss,activityPub)
-            Tag::Proxy {
-                id: feed_id,
-                protocol: nostr_sdk::prelude::Protocol::Rss,
-            }
+    fn get_nip48(mut tags: &Vec<Tag>, feed_id: String) -> Tag {
+        // Declare NIP-48.
+        // NIP-48 : declares to be a proxy from an external signal (rss,activityPub)
+        Tag::Proxy {
+            id: feed_id,
+            protocol: nostr_sdk::prelude::Protocol::Rss,
+        }
     }
 
-     fn get_recommended_relays(recommended_relays_ids: Vec<String>, relays: &[Relay]) -> Vec<Tag> {
+    fn get_recommended_relays(recommended_relays_ids: Vec<String>, relays: &[Relay]) -> Vec<Tag> {
         let mut relay_tags = Vec::new();
         for relay_name in recommended_relays_ids {
             let r = relays.iter().find(|relay| relay.name == relay_name);
@@ -263,9 +263,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_nip_48_signal() {
-
-    }
+    fn test_nip_48_signal() {}
 
     #[test]
     fn test_get_tags() {
@@ -297,13 +295,11 @@ mod tests {
 
     #[test]
     fn test_nip_48() {
-
         let feed_id = "https://www.test.com";
         let mut tags: Vec<Tag> = [].to_vec();
         let nip_48 = RssNostrJob::get_nip48(&tags, feed_id.clone().to_string());
 
-        
-        assert_eq!(nip_48.kind(),TagKind::Proxy);
+        assert_eq!(nip_48.kind(), TagKind::Proxy);
     }
 
     #[test]


### PR DESCRIPTION
Implements NIP-48 which allow to flag notes as a replica of another stream, e.g: ActivityPub and RSS.

