### PR TITLE
Add dry run mode to nostrss core

### DIFF
--- a/nostrss-core/README.md
+++ b/nostrss-core/README.md
@@ -100,3 +100,13 @@ An example template is provided in the [fixtures](./src/fixtures/default.templat
 Cronjob rules are defined in the [feeds config file](./nostrss-core/src/fixtures/rss.json) following the [cron crate rules](https://crates.io/crates/cron).
 
 For each tick the remote feed will be matched with a local fingerprint, for which, any unmatching entry against of the feed will be broadcasted to relays. 
+
+### Dry run mode
+
+You can run the program in a `dry-run` mode, so the program will run the whole processes as usual but will avoid broadcasting the final result onto the network. 
+
+When activating the `dry-run` mode, the programm will log the json that would have been broadcasted into the `STDOUT`. 
+
+To run the `dry-run` mode use the `--dry-run` flag when instanciating `nostrss` : 
+
+> nostrss --relays <path/to/relays> --feeds <path/to/feeds> --profiles <path/to/profiles> --update <boolean> --dry-run

--- a/nostrss-core/src/app/app.rs
+++ b/nostrss-core/src/app/app.rs
@@ -35,6 +35,10 @@ pub struct AppConfig {
     #[arg(long)]
     pub private_key: Option<String>,
 
+    // Run the progam without broadcasting onto the network
+    #[arg(long)]
+    pub dry_run: Option<bool>,
+
     #[arg(long)]
     pub update: Option<bool>,
 }
@@ -119,6 +123,10 @@ impl App {
 
     pub async fn get_profiles(&self) -> Arc<Mutex<HashMap<String, Profile>>> {
         Arc::new(Mutex::new(self.nostr_service.profiles.clone()))
+    }
+
+    pub async fn get_config(&self) -> Arc<Mutex<AppConfig>> {
+        Arc::new(Mutex::new(self.config.clone()))
     }
 
     pub async fn update_profile_config(&self) -> bool {

--- a/nostrss-core/src/app/app.rs
+++ b/nostrss-core/src/app/app.rs
@@ -36,7 +36,7 @@ pub struct AppConfig {
     pub private_key: Option<String>,
 
     /// Run the progam without broadcasting onto the network
-    #[arg(long,action)]
+    #[arg(long, action)]
     pub dry_run: bool,
 
     #[arg(long)]

--- a/nostrss-core/src/app/app.rs
+++ b/nostrss-core/src/app/app.rs
@@ -35,9 +35,9 @@ pub struct AppConfig {
     #[arg(long)]
     pub private_key: Option<String>,
 
-    // Run the progam without broadcasting onto the network
-    #[arg(long)]
-    pub dry_run: Option<bool>,
+    /// Run the progam without broadcasting onto the network
+    #[arg(long,action)]
+    pub dry_run: bool,
 
     #[arg(long)]
     pub update: Option<bool>,

--- a/nostrss-core/src/app/mod.rs
+++ b/nostrss-core/src/app/mod.rs
@@ -60,6 +60,7 @@ pub mod test_utils {
                 Arc::new(Mutex::new(app.feeds_map.clone())),
                 app.nostr_service.get_client().await,
                 app.get_profiles().await,
+                app.get_config().await,
             )
             .await;
 

--- a/nostrss-core/src/grpc/feed_request.rs
+++ b/nostrss-core/src/grpc/feed_request.rs
@@ -48,6 +48,7 @@ impl FeedRequestHandler {
         let map = Arc::new(Mutex::new(app.feeds_map.clone()));
         let profiles = app.get_profiles().await;
         let client = app.nostr_service.get_client().await;
+        let config = app.get_config().await;
         app.rss.feeds.push(feed.clone());
 
         let job = schedule(
@@ -56,6 +57,7 @@ impl FeedRequestHandler {
             map,
             client,
             profiles,
+            config,
         )
         .await;
 

--- a/nostrss-core/src/grpc/mod.rs
+++ b/nostrss-core/src/grpc/mod.rs
@@ -62,6 +62,7 @@ mod grpctest_utils {
                 Arc::new(Mutex::new(app.feeds_map.clone())),
                 app.nostr_service.get_client().await,
                 app.get_profiles().await,
+                app.get_config().await,
             )
             .await;
 

--- a/nostrss-core/src/main.rs
+++ b/nostrss-core/src/main.rs
@@ -92,12 +92,20 @@ async fn main() -> Result<()> {
 
         // Arc the map of feeds for use in the scheduled jobs
         let maps = Arc::new(Mutex::new(app_lock.feeds_map.clone()));
-
+        let app_config_arc = app_lock.get_config().await;
         // Extract cronjob rule
         let scheduler_rule = f.schedule.as_str();
         let profiles = app_lock.get_profiles().await;
         // Call job builder
-        let job = schedule(scheduler_rule, feed, maps, client_arc, profiles).await;
+        let job = schedule(
+            scheduler_rule,
+            feed,
+            maps,
+            client_arc,
+            profiles,
+            app_config_arc,
+        )
+        .await;
         info!("Job id for feed {:?}: {:?}", f.name, job.guid());
 
         // Load job reference in jobs map

--- a/nostrss-core/src/scheduler/scheduler.rs
+++ b/nostrss-core/src/scheduler/scheduler.rs
@@ -212,12 +212,12 @@ impl RssNostrJob {
 
                         match event {
                             Ok(e) => {
-                                let dry_run_flag = app_config_lock.dry_run.unwrap_or(false);
+                                let dry_run_flag = app_config_lock.dry_run;
 
                                 match dry_run_flag {
                                     true => {
-                                        log::info!("Running in dry-run mode, therefore skipping publishing. Run in debug mode for event serialized details");
-                                        log::debug!("{:?}", e.as_json());
+                                        
+                                        log::info!("dry-mode on : {:?}", e.as_json());
                                     }
                                     false => match client.send_event(e).await {
                                         Ok(event_id) => {

--- a/nostrss-core/src/scheduler/scheduler.rs
+++ b/nostrss-core/src/scheduler/scheduler.rs
@@ -216,7 +216,6 @@ impl RssNostrJob {
 
                                 match dry_run_flag {
                                     true => {
-                                        
                                         log::info!("dry-mode on : {:?}", e.as_json());
                                     }
                                     false => match client.send_event(e).await {

--- a/nostrss-core/src/scheduler/scheduler.rs
+++ b/nostrss-core/src/scheduler/scheduler.rs
@@ -1,11 +1,12 @@
 use feed_rs::model::Entry;
 use log::{debug, error};
-use nostr_sdk::{Client, EventBuilder, Keys, Tag};
+use nostr_sdk::{Client, EventBuilder, JsonUtil, Keys, Tag};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{Mutex, MutexGuard};
 use tokio_cron_scheduler::Job;
 
 use crate::{
+    app::app::AppConfig,
     nostr::relay::Relay,
     profiles::config::Profile,
     rss::{config::Feed, parser::RssParser},
@@ -19,6 +20,7 @@ pub async fn schedule(
     map: Arc<Mutex<HashMap<String, Vec<String>>>>,
     client: Arc<Mutex<Client>>,
     profiles: Arc<Mutex<HashMap<String, Profile>>>,
+    app_config: Arc<Mutex<AppConfig>>,
 ) -> Job {
     // Create a copy of the map arc that will be solely used into the job
     let map_job_copy = Arc::clone(&map);
@@ -38,6 +40,8 @@ pub async fn schedule(
 
         let map_arc = Arc::clone(&map_job_copy);
         let profiles_arc = Arc::clone(&profiles);
+
+        let app_config_arc = Arc::clone(&app_config);
         let client_arc = Arc::clone(&client);
         Box::pin(async move {
             let mut map_lock = map_arc.lock().await;
@@ -48,7 +52,7 @@ pub async fn schedule(
             let client_lock = client_arc.lock().await;
 
             let profiles_lock = profiles_arc.lock().await;
-
+            let app_config_lock = app_config_arc.lock().await;
             match RssParser::get_items(feed.url.to_string()).await {
                 Ok(entries) => {
                     // Calls the method that
@@ -59,6 +63,7 @@ pub async fn schedule(
                         &mut map,
                         client_lock,
                         profiles_lock,
+                        app_config_lock,
                     )
                     .await;
 
@@ -129,6 +134,7 @@ impl RssNostrJob {
     }
 
     pub async fn _client_clean(_client: Client) {}
+
     pub async fn process(
         feed: Feed,
         profile_ids: Vec<String>,
@@ -136,6 +142,7 @@ impl RssNostrJob {
         map: &mut Vec<String>,
         client: MutexGuard<'_, Client>,
         profiles_lock: MutexGuard<'_, HashMap<String, Profile>>,
+        app_config_lock: MutexGuard<'_, AppConfig>,
     ) {
         for entry in entries {
             let entry_id = &entry.id;
@@ -204,10 +211,22 @@ impl RssNostrJob {
                             .to_pow_event(&keys, profile.pow_level);
 
                         match event {
-                            Ok(e) => match client.send_event(e).await {
-                                Ok(event_id) => log::info!("Entry published with id {}", event_id),
-                                Err(e) => log::error!("Error publishing entry : {}", e),
-                            },
+                            Ok(e) => {
+                                let dry_run_flag = app_config_lock.dry_run.unwrap_or(false);
+
+                                match dry_run_flag {
+                                    true => {
+                                        log::info!("Running in dry-run mode, therefore skipping publishing. Run in debug mode for event serialized details");
+                                        log::debug!("{:?}", e.as_json());
+                                    }
+                                    false => match client.send_event(e).await {
+                                        Ok(event_id) => {
+                                            log::info!("Entry published with id {}", event_id)
+                                        }
+                                        Err(e) => log::error!("Error publishing entry : {}", e),
+                                    },
+                                }
+                            }
                             Err(_) => panic!("Note couldn't be sent"),
                         };
 


### PR DESCRIPTION
Adds the `--dry-run` flag to `nostrss` core application.

The feature should run and be valid. I'll run a few tests on a local relay first to ensure everything runs as expected before merging and releasing it. 

**TESTS** : 
- [x] Program behaves as expected on LAN relay
- [x] Program behaves as expected on local relay
- [x] Program behaves as expected on remote relay